### PR TITLE
fix.vscode: pass planEditorProvider to deleteSessionWithConfirm in viewSession

### DIFF
--- a/packages/vscode/src/commands/index.ts
+++ b/packages/vscode/src/commands/index.ts
@@ -151,7 +151,7 @@ export function registerCommands(
           await vscode.window.showTextDocument(doc);
           break;
         case 'delete':
-          await deleteSessionWithConfirm(item, sessionTreeProvider);
+          await deleteSessionWithConfirm(item, sessionTreeProvider, planEditorProvider);
           break;
       }
     })


### PR DESCRIPTION
fix(vscode): pass planEditorProvider to deleteSessionWithConfirm in viewSession

Add missing planEditorProvider parameter when calling deleteSessionWithConfirm
from the viewSession command's 'Delete Session' action. This fixes a runtime
crash when deleting sessions via the quick pick menu.

Fixes #2
