### PR TITLE
fix(vscode): add curly braces to MCP command string syntax

### DIFF
--- a/packages/vscode/src/commands/index.ts
+++ b/packages/vscode/src/commands/index.ts
@@ -54,7 +54,7 @@ export function registerCommands(
       }
 
       // Generate command for Claude
-      const command = `pl_submit(session_id: "${session.id}", plan: "여기에 plan 작성")`;
+      const command = `pl_submit({ session_id: "${session.id}", plan: "여기에 plan 작성" })`;
 
       // Check auto copy setting
       const config = vscode.workspace.getConfiguration('planLoop');

--- a/packages/vscode/src/webview/planEditor.ts
+++ b/packages/vscode/src/webview/planEditor.ts
@@ -933,7 +933,7 @@ function getSessionHtml(session: Session): string {
       </div>
     `;
   } else if (session.status === 'drafting') {
-    const examplePrompt = `pl_submit(session_id: "${session.id}", plan: "여기에 plan 작성")`;
+    const examplePrompt = `pl_submit({ session_id: "${session.id}", plan: "여기에 plan 작성" })`;
     feedbackHtml = `
       <div class="drafting-guide">
         <div class="guide-header">🎯 Goal 설정 완료!</div>


### PR DESCRIPTION
fix(vscode): add curly braces to MCP command string syntax

The copied MCP command was using incorrect syntax without curly braces,
causing errors when users paste and execute the command.

- Fix command string in newSession command (commands/index.ts:57)
- Fix example prompt in Plan Editor webview (planEditor.ts:936)

Before: pl_submit(session_id: "...", plan: "...")
After:  pl_submit({ session_id: "...", plan: "..." })

Closes #3
