### PR TITLE
refactor(vscode): deduplicate state logic using core library

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,5 +5,5 @@
 
 export * from './types.js';
 export * as state from './state.js';
-export { isValidSessionId, normalizeSessionId } from './state.js';
+export { isValidSessionId, normalizeSessionId, getStateDir, getSessionFilePath, listFull } from './state.js';
 export * from './tools.js';

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -128,5 +128,7 @@
     "esbuild": "^0.20.0",
     "typescript": "^5.0.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "@joseph0926/plan-loop-core": "workspace:*"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,10 @@ importers:
         version: 2.1.9(@types/node@20.19.30)
 
   packages/vscode:
+    dependencies:
+      '@joseph0926/plan-loop-core':
+        specifier: workspace:*
+        version: link:../core
     devDependencies:
       '@types/node':
         specifier: ^20.0.0


### PR DESCRIPTION
Replace direct file I/O in VSCode extension with core state management:

- Add getStateDir(), getSessionFilePath() exports to core for path access
- Add listFull() function to core for efficient full session listing
  - Does not create directory if not exists (preserves original behavior)
  - Returns full Session objects to avoid double file reads
- Remove duplicate type definitions (Session, Rating, Plan, Feedback, SessionStatus)
- Replace _loadSession/_saveSession with state.load/state.save
- Replace createSession() with state.create()
- Replace deleteSession() with state.remove()
- Update SessionTreeProvider.getSessions() to use listFull()

Benefits:
- Single source of truth for state transitions
- Consistent Zod schema validation on all loads
- Path traversal protection applied automatically
- Atomic file operations (temp + rename) guaranteed

Closes #7
