### PR TITLE
feat(core): add plan_version parameter to pl_feedback for optimistic concurrency

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -196,10 +196,21 @@ pl_feedback({ session_id: "...", rating: "🟢", content: "LGTM" })
 
 ## 설계 결정
 
-### 최신 plan 자동 매핑
-- `pl_feedback`은 항상 최신 plan에 매핑됨
-- planVersion 파라미터 없음 (단순화)
-- **Trade-off**: 동시 호출 시 race condition 가능 → 운영 규칙으로 관리
+### plan_version을 통한 Optimistic Concurrency
+- `pl_feedback`은 선택적 `plan_version` 파라미터 지원
+- 제공 시: 현재 plan version과 비교하여 불일치 시 에러 반환
+- 미제공 시: 기존 동작 유지 (최신 plan에 자동 매핑, 하위 호환성)
+
+```text
+# plan_version 없이 (기본 동작)
+pl_feedback({ session_id: "...", rating: "🟢", content: "LGTM" })
+
+# plan_version으로 race condition 방지
+pl_feedback({ session_id: "...", rating: "🟢", content: "LGTM", plan_version: 1 })
+# → version 불일치 시: "Plan version mismatch: expected=2, provided=1"
+```
+
+**참고**: `plan_version`은 1-based 정수입니다 (첫 번째 plan은 version=1).
 
 ### 역할 구분
 - 서버는 호출자를 검증하지 않음

--- a/README.md
+++ b/README.md
@@ -102,6 +102,21 @@ pl_feedback({ session_id: "...", rating: "🟢", content: "LGTM" })
 
 See [AGENTS.md](AGENTS.md) for detailed workflows and feedback auto-completion guide.
 
+### Optimistic Concurrency with plan_version
+
+`pl_feedback` supports an optional `plan_version` parameter to prevent race conditions in multi-agent workflows:
+
+```text
+# Without plan_version (default behavior)
+pl_feedback({ session_id: "...", rating: "🟢", content: "LGTM" })
+
+# With plan_version for race condition prevention
+pl_feedback({ session_id: "...", rating: "🟢", content: "LGTM", plan_version: 1 })
+# → On mismatch: "Plan version mismatch: expected=2, provided=1"
+```
+
+**Note**: `plan_version` is a 1-based integer (first plan is version=1).
+
 ## State storage
 
 Session files are stored under `~/.plan-loop/sessions/`.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -97,6 +97,10 @@ const TOOL_DEFINITIONS = [
           type: 'string',
           description: 'Feedback content',
         },
+        plan_version: {
+          type: 'integer',
+          description: 'Expected plan version (1-based) for optimistic concurrency check. If provided and mismatched, returns error with current version.',
+        },
       },
       required: ['session_id', 'rating', 'content'],
     },

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -79,6 +79,7 @@ export interface PlFeedbackInput {
   session_id: string;
   rating: Rating;
   content: string;
+  plan_version?: number;  // Optimistic concurrency: 제공 시 현재 plan version과 비교
 }
 
 export interface PlGetFeedbackInput {


### PR DESCRIPTION
Prevent race conditions in multi-agent workflows by allowing callers to
specify the expected plan version when submitting feedback.

Changes:
- Add optional plan_version parameter to PlFeedbackInput
- Validate plan_version is an integer and matches current plan version
- Return descriptive error on version mismatch with current version info
- Update MCP tool schema with type: 'integer'
- Add unit tests for version matching, mismatch, and backward compatibility
- Document feature in README.md and README.ko.md

Closes #6
